### PR TITLE
requirements.txt: Add torchaudio==2.0.2 in to requirements.txt

### DIFF
--- a/MOFA-Video-Hybrid/requirements.txt
+++ b/MOFA-Video-Hybrid/requirements.txt
@@ -2,6 +2,7 @@ diffusers==0.24.0
 gradio==4.5.0
 scikit-image
 torch==2.0.1
+torchaudio==2.0.2
 torchvision==0.15.2
 einops==0.8.0
 accelerate==0.30.1
@@ -19,3 +20,4 @@ kornia==0.7.2
 yacs==0.1.8
 gfpgan==1.3.8
 numpy==1.23.0
+


### PR DESCRIPTION
fix error message

Installing collected packages: torch
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. torchaudio 2.3.1 requires torch==2.3.1, but you have torch 2.0.1 which is incompatible.

when use pip install -r requirements.txt